### PR TITLE
Fix typo in notebook

### DIFF
--- a/finished_files/001_equal_weight_S&P_500.ipynb
+++ b/finished_files/001_equal_weight_S&P_500.ipynb
@@ -265,7 +265,7 @@
    "source": [
     "## Calculating the Number of Shares to Buy\n",
     "\n",
-    "As you can see in the DataFrame above, we stil haven't calculated the number of shares of each stock to buy.\n",
+    "As you can see in the DataFrame above, we still haven't calculated the number of shares of each stock to buy.\n",
     "\n",
     "We'll do that next."
    ]


### PR DESCRIPTION
## Summary
- correct a typo in a markdown cell of `001_equal_weight_S&P_500.ipynb`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840389fe2288331958a1039e1be23c9